### PR TITLE
Fixed bug with dim_head and dim

### DIFF
--- a/sinkhorn_transformer/sinkhorn_transformer.py
+++ b/sinkhorn_transformer/sinkhorn_transformer.py
@@ -570,7 +570,7 @@ class SinkhornCausalAttention(nn.Module):
 class SinkhornSelfAttention(nn.Module):
     def __init__(self, dim, bucket_size, max_seq_len, heads = 8, dim_head = None, kv_bucket_size = None, causal = False, non_permutative = True, sinkhorn_iter = 5, n_sortcut = 0, temperature = 0.75, attn_dropout = 0., dropout = 0., context_only = False, use_simple_sort_net = False, n_local_attn_heads = 0, n_top_buckets = 1):
         super().__init__()
-        assert divisible_by(dim, heads), f'dimension {dim} must be divisible by the number of heads {heads}'
+        assert dim_head or divisible_by(dim, heads), f'If dim_head is None, dimension {dim} must be divisible by the number of heads {heads}'
         assert not (causal and n_sortcut > 0), 'sortcut can only be used for non causal attention'
         assert not (causal and context_only), 'context only self attention layer cannot be causal'
         assert n_local_attn_heads <= heads, 'number of local attention heads cannot exceed total heads'


### PR DESCRIPTION
Hi Phil! Thank you again for this repo and helping me to inspire my linformer repo from yours!

I was just browsing your code, and I just wanted to fix a quick assert statement. If I were to run this code on the current master branch, it would create an error:

```python3
import torch
from sinkhorn_transformer import SinkhornTransformer

model = SinkhornTransformer(
    dim = 1023,
    heads = 8,
    depth = 12,
    bucket_size = 128,
    dim_head = 25,
)

x = torch.randn(1, 512, 1023)
model(x) # (1, 512, 1023)
print("Success!")
```

The error produced is this:

```
AssertionError: dimension 1023 must be divisible by the number of heads 8
```

However, I overrode the head dimension, and if I saw correctly, this assert statement only should check this if the `dim_head` variable is `None`. This pull request aims to fix that, and with this pull request, the following prints:

```
Success!
```

Edit: If I was supposed to create an issue first, sorry! I am not so used to github yet and the proper contribution guidelines, so let me know if next time I should open up an issue :sweat_smile: 